### PR TITLE
[FIX] MITM using https resource

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,4 +1,4 @@
-wget http://download.redis.io/releases/redis-2.8.17.tar.gz
+wget https://download.redis.io/releases/redis-2.8.17.tar.gz
 tar xzf redis-2.8.17.tar.gz
 rm redis-2.8.17.tar.gz
 cd redis-2.8.17


### PR DESCRIPTION
### 📊 Metadata *

#### Bounty URL: https://www.huntr.dev/bounties/1-npm-redis-srvr

### ⚙️ Description *

The `redis-srvr` module was vulnerable against `MITM` since a `http` resource was downloaded.

### 💻 Technical Description *

I simply switched to `https` the resource download url 👍 
The server's certificate is valid and so it's protected as well

### 🐛 Proof of Concept (PoC) *

Not needed

### 🔥 Proof of Fix (PoF) *

Not needed 

### 👍 User Acceptance Testing (UAT)

All works 👍 